### PR TITLE
Fix build breaks

### DIFF
--- a/src/Directory.build.props
+++ b/src/Directory.build.props
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="Nerdbank.GitVersioning" Version="3.1.68" PrivateAssets="all" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All"/>
     <PackageReference Include="Microsoft.SourceLink.Vsts.Git" Version="1.0.0-beta2-19367-01" PrivateAssets="All"/>

--- a/src/SignService/SignService.csproj
+++ b/src/SignService/SignService.csproj
@@ -73,6 +73,7 @@
     <PackageReference Include="Microsoft.Azure.Management.ResourceManager" Version="2.4.0-preview" />
     <PackageReference Include="Microsoft.Data.Services.Client" Version="5.8.4" />
     <PackageReference Include="Microsoft.Extensions.Logging.ApplicationInsights" Version="2.12.1" />
+    <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="NuGetKeyVaultSignTool.Core" Version="2.0.28" />
     <PackageReference Include="RSAKeyVaultProvider" Version="1.1.57" />


### PR DESCRIPTION
This removes the requirement of installing the net47 targeting pack, and adds the missing package reference for accessing the registry in .NET Core.

Fixes #199 