### PR TITLE
Remove dependency on Application Insights resource

### DIFF
--- a/arm/ArmDeploy/azuredeploy.json
+++ b/arm/ArmDeploy/azuredeploy.json
@@ -163,8 +163,7 @@
           "name": "Microsoft.AspNetCore.AzureAppServices.SiteExtension",
           "type": "siteextensions",
           "dependsOn": [
-            "[resourceId('Microsoft.Web/Sites', parameters('webSiteName'))]",
-            "[resourceId('Microsoft.Web/Sites/siteextensions', parameters('webSiteName'), 'Microsoft.ApplicationInsights.AzureWebSites')]"
+            "[resourceId('Microsoft.Web/Sites', parameters('webSiteName'))]"
           ],
           "properties": {
           }


### PR DESCRIPTION
Fixes #264

Recently the Microsoft.ApplicationInsights.AzureWebSites resource was removed from the ARM template, but this dependency on it was not, causing a validation error with the template. This commit removes the old dependsOn clause.