### PR TITLE
Avoid reflection in CryptoConfigShims

### DIFF
--- a/src/SignService/Utils/CryptoConfigShims.cs
+++ b/src/SignService/Utils/CryptoConfigShims.cs
@@ -4,16 +4,6 @@ namespace System.Security.Cryptography.Xml
 {
     public abstract class RSAPKCS1SignatureDescription : SignatureDescription
     {
-        static readonly MethodInfo CryptoHelpersCreateFromName;
-
-        static RSAPKCS1SignatureDescription()
-        {
-            // Get the CryptoHelpers impl
-            var helperType = Type.GetType("System.Security.Cryptography.Xml.CryptoHelpers, System.Security.Cryptography.Xml");
-
-            CryptoHelpersCreateFromName = helperType.GetTypeInfo().GetDeclaredMethod("CreateFromName");
-        }
-
         public RSAPKCS1SignatureDescription(string hashAlgorithmName)
         {
             KeyAlgorithm = typeof(RSA).AssemblyQualifiedName;
@@ -24,7 +14,7 @@ namespace System.Security.Cryptography.Xml
 
         public sealed override AsymmetricSignatureDeformatter CreateDeformatter(AsymmetricAlgorithm key)
         {
-            var item = (AsymmetricSignatureDeformatter)CryptoHelpersCreateFromName.Invoke(null, new object[] { DeformatterAlgorithm });
+            var item = (AsymmetricSignatureDeformatter)CryptoConfig.CreateFromName(DeformatterAlgorithm);
             item.SetKey(key);
             item.SetHashAlgorithm(DigestAlgorithm);
             return item;
@@ -32,7 +22,7 @@ namespace System.Security.Cryptography.Xml
 
         public sealed override AsymmetricSignatureFormatter CreateFormatter(AsymmetricAlgorithm key)
         {
-            var item = (AsymmetricSignatureFormatter)CryptoHelpersCreateFromName.Invoke(null, new object[] { FormatterAlgorithm });
+            var item = (AsymmetricSignatureFormatter)CryptoConfig.CreateFromName(FormatterAlgorithm);
             item.SetKey(key);
             item.SetHashAlgorithm(DigestAlgorithm);
             return item;


### PR DESCRIPTION
Fixes #266

The previous code attempts to invoke an internal method in .NET Core as if it's non-generic, but in recent framework versions it _is_ generic and the invocation fails. This commit replaces the call with a non-reflective call on a public method to avoid similar backwards-breaking changes in the future.

I've tested this code, and it successfully signs a VSTO ClickOnce archive.

Note: There are some special cases handled by the internal method [System.Security.Cryptography.Xml.CryptoHelpers.CreateFromName](https://github.com/dotnet/runtime/blob/master/src/libraries/System.Security.Cryptography.Xml/src/System/Security/Cryptography/Xml/CryptoHelpers.cs) that are not handled by the replacement method, `CryptoConfig.CreateFromName` (they're explicitly listed in a switch in `CryptoHelpers.CreateFromKnownName`. However, the only names used in `CryptoConfigShims` are for `RSAPKCS1SignatureFormatter` and `RSAPKCS1SignatureDeformatter`, neither of which appear to be in the list of special cases. So for the purposes of `CryptoConfigShims`, I think the new behaviour is equivalent.