### PR TITLE
Change base retry delay to 5 sec

### DIFF
--- a/src/SignService/SigningTools/AzureSignToolSignService.cs
+++ b/src/SignService/SigningTools/AzureSignToolSignService.cs
@@ -74,6 +74,7 @@ namespace SignService
                 {
                     logger.LogInformation($"Performing attempt #{attempt} of 3 attempts after {retry.TotalSeconds}s");
                     Thread.Sleep(retry);
+                    retry = TimeSpan.FromSeconds(Math.Pow(retry.TotalSeconds, 1.5));
                 }
 
                 if (RunSignTool(signer, file, description, descriptionUrl))
@@ -82,8 +83,6 @@ namespace SignService
                 }
 
                 attempt++;
-
-                retry = TimeSpan.FromSeconds(Math.Pow(retry.TotalSeconds, 1.5));
 
             } while (attempt <= 3);
 

--- a/src/SignService/SigningTools/MageSignService.cs
+++ b/src/SignService/SigningTools/MageSignService.cs
@@ -207,6 +207,7 @@ namespace SignService.SigningTools
                 {
                     logger.LogInformation($"Performing attempt #{attempt} of 3 attempts after {retry.TotalSeconds}s");
                     Thread.Sleep(retry);
+                    retry = TimeSpan.FromSeconds(Math.Pow(retry.TotalSeconds, 1.5));
                 }
 
                 if (RunSignTool(args, inputFile, hashMode, rsaPrivateKey, publicCertificate, timestampUrl))
@@ -216,8 +217,6 @@ namespace SignService.SigningTools
                 }
 
                 attempt++;
-
-                retry = TimeSpan.FromSeconds(Math.Pow(retry.TotalSeconds, 1.5));
 
             } while (attempt <= 3);
 

--- a/src/SignService/SigningTools/NuGetSignService.cs
+++ b/src/SignService/SigningTools/NuGetSignService.cs
@@ -83,6 +83,7 @@ namespace SignService.SigningTools
                 {
                     logger.LogInformation($"Performing attempt #{attempt} of 3 attempts after {retry.TotalSeconds}s");
                     await Task.Delay(retry);
+                    retry = TimeSpan.FromSeconds(Math.Pow(retry.TotalSeconds, 1.5));
                 }
 
                 if (await RunSignTool(file, args))
@@ -92,8 +93,6 @@ namespace SignService.SigningTools
                 }
 
                 attempt++;
-
-                retry = TimeSpan.FromSeconds(Math.Pow(retry.TotalSeconds, 1.5));
 
             } while (attempt <= 3);
 

--- a/src/SignService/SigningTools/VsixSignService.cs
+++ b/src/SignService/SigningTools/VsixSignService.cs
@@ -83,6 +83,7 @@ namespace SignService.SigningTools
                 {
                     logger.LogInformation($"Performing attempt #{attempt} of 3 attempts after {retry.TotalSeconds}s");
                     await Task.Delay(retry);
+                    retry = TimeSpan.FromSeconds(Math.Pow(retry.TotalSeconds, 1.5));
                 }
 
                 if (await RunSignTool(file, config, timestampUrl, alg))
@@ -92,8 +93,6 @@ namespace SignService.SigningTools
                 }
 
                 attempt++;
-
-                retry = TimeSpan.FromSeconds(Math.Pow(retry.TotalSeconds, 1.5));
 
             } while (attempt <= 3);
 


### PR DESCRIPTION
All signing methods perform 3 attempts to sign.

The retrying code looks like the intention is to start with a delay of 5 seconds and then increase the delay exponentially: 5s before attempt 2, 11.1s before attempt 3.
Because the increase happens before the first retry, the actual delay times are 11.1s before attempt 2 and 37.3s before attempt 3.

This change makes the actual behaviour match the assumed intention.