### PR TITLE
Remove service exception handler

### DIFF
--- a/src/SignService/Startup.cs
+++ b/src/SignService/Startup.cs
@@ -170,7 +170,6 @@ namespace SignService
             }
             else
             {
-                app.UseExceptionHandler("/Error");
                 app.UseHsts();
             }
 


### PR DESCRIPTION
As discussed in #356, the current behavior of SignService is to return 404 errors when deployed because it uses the default asp.net core error handling and the current Error action is missing a route attribute.

This PR simply remove the default UseExceptionHandler call, to let asp.net core return a raw 500 error when using the API. This will ease debugging when a problem occurs.

Fix #356