### PR TITLE
SignClient: add --secret option check

### DIFF
--- a/src/SignClient/SignCommand.cs
+++ b/src/SignClient/SignCommand.cs
@@ -70,6 +70,12 @@ namespace SignClient
                     return EXIT_CODES.INVALID_OPTIONS;
                 }
 
+                if (!clientSecret.HasValue())
+                {
+                    signCommandLineApplication.Error.WriteLine("--secret parameter is required");
+                    return EXIT_CODES.INVALID_OPTIONS;
+                }
+
                 if(!maxConcurrency.HasValue())
                 {
                     maxConcurrency.Values.Add("4"); // default to 4


### PR DESCRIPTION
This option is in fact required and will raise a NRE is not set.

This PR simply add a check like other required parameters.