### PR TITLE
Add fallback logic for appx tag

### DIFF
--- a/src/SignService/SigningTools/AppInstallerService.cs
+++ b/src/SignService/SigningTools/AppInstallerService.cs
@@ -45,7 +45,7 @@ namespace SignService.SigningTools
                     manifest = XDocument.Load(fs, LoadOptions.PreserveWhitespace);
                     XNamespace ns = "http://schemas.microsoft.com/appx/appinstaller/2017/2";
 
-                    var idElement = manifest.Root?.Element(ns + "MainBundle");
+                    var idElement = manifest.Root?.Element(ns + "MainBundle") ?? manifest.Root?.Element(ns + "MainPackage"); // look for appxbundle tag, if not found check for appx tag
                     idElement?.SetAttributeValue("Publisher", publisher);
                 }
 


### PR DESCRIPTION
This PR adds logic for finding the tag with the `Publisher` attribute for `.appx` files which has a different element name to `.appxbundle` files.  

It does this via a simple `??` fallback if the `appxbundle` tag cannot be found.