### PR TITLE
Do not require .manifest file to be included in the filter to be signed.

### DIFF
--- a/src/SignService/SigningTools/MageSignService.cs
+++ b/src/SignService/SigningTools/MageSignService.cs
@@ -142,7 +142,7 @@ namespace SignService.SigningTools
                 }
                 catch (Exception ex)
                 {
-                    throw new InvalidOperationException("Could not file the .manifest file in the submitted files. Exactly one .manifest file is supposed to be included in the payload to be signed", ex);
+                    throw new InvalidOperationException("Could not find the .manifest file in the submitted files. Exactly one .manifest file is supposed to be included in the payload to be signed", ex);
                 }
 
                 var fileArgs = $@"-update ""{manifestFile}"" {args}";

--- a/src/SignService/SigningTools/MageSignService.cs
+++ b/src/SignService/SigningTools/MageSignService.cs
@@ -135,7 +135,15 @@ namespace SignService.SigningTools
                 // Inner files are now signed
                 // now look for the manifest file and sign that
 
-                var manifestFile = zip.FilteredFilesInDirectory.Single(f => ".manifest".Equals(Path.GetExtension(f), StringComparison.OrdinalIgnoreCase));
+                string manifestFile;
+                try
+                {
+                    manifestFile = zip.FilesInDirectory.Single(f => ".manifest".Equals(Path.GetExtension(f), StringComparison.OrdinalIgnoreCase));
+                }
+                catch (Exception ex)
+                {
+                    throw new InvalidOperationException("Could not file the .manifest file in the submitted files. Exactly one .manifest file is supposed to be included in the payload to be signed", ex);
+                }
 
                 var fileArgs = $@"-update ""{manifestFile}"" {args}";
 


### PR DESCRIPTION
Better error message when the manifest file is not found.

Fix #355.